### PR TITLE
Add Retrofit and Moshi dependencies for network requests

### DIFF
--- a/frontend-android/.idea/deviceManager.xml
+++ b/frontend-android/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/frontend-android/app/build.gradle.kts
+++ b/frontend-android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -56,4 +57,9 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.moshi.kotlin)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.moshi)
+    ksp(libs.moshi.kotlin.codegen)
+
 }

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/mapper/RetrieveCourseInfoMapper.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/mapper/RetrieveCourseInfoMapper.kt
@@ -1,0 +1,17 @@
+package edu.gsu.pantherwatch.data.mapper
+
+import edu.gsu.pantherwatch.data.model.RetrieveCourseInfoRequest
+
+fun RetrieveCourseInfoRequest.toQueryMap(): Map<String, String> {
+    val queryMap = mutableMapOf<String, String>()
+
+    queryMap["txt_level"] = txtLevel
+    queryMap["txt_subject"] = txtSubject
+    queryMap["txt_courseNumber"] = txtCourseNumber
+    queryMap["txt_term"] = txtTerm
+
+    // ✅ Optional fields (added only if non-null) (Leaving here for as a template for future purposes
+    // txtLevel?.let { queryMap["txt_level"] = it }
+
+    return queryMap
+}

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/CourseData.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/CourseData.kt
@@ -1,0 +1,76 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CourseData(
+    @field:Json(name = "termDesc")
+    val termDesc: String?,
+    
+    @field:Json(name = "courseReferenceNumber")
+    val courseReferenceNumber: String?,
+    
+    @field:Json(name = "partOfTerm")
+    val partOfTerm: String?,
+    
+    @field:Json(name = "courseNumber")
+    val courseNumber: String?,
+    
+    @field:Json(name = "subject")
+    val subject: String?,
+    
+    @field:Json(name = "subjectDescription")
+    val subjectDescription: String?,
+    
+    @field:Json(name = "sequenceNumber")
+    val sequenceNumber: String?,
+    
+    @field:Json(name = "campusDescription")
+    val campusDescription: String?,
+    
+    @field:Json(name = "scheduleTypeDescription")
+    val scheduleTypeDescription: String?,
+    
+    @field:Json(name = "courseTitle")
+    val courseTitle: String?,
+    
+    @field:Json(name = "creditHours")
+    val creditHours: Int,
+    
+    @field:Json(name = "maximumEnrollment")
+    val maximumEnrollment: Int,
+    
+    @field:Json(name = "enrollment")
+    val enrollment: Int,
+    
+    @field:Json(name = "seatsAvailable")
+    val seatsAvailable: Int,
+    
+    @field:Json(name = "waitCapacity")
+    val waitCapacity: Int,
+    
+    @field:Json(name = "waitAvailable")
+    val waitAvailable: Int,
+    
+    @field:Json(name = "creditHourHigh")
+    val creditHourHigh: Int,
+    
+    @field:Json(name = "creditHourLow")
+    val creditHourLow: Int,
+    
+    @field:Json(name = "linkIdentifier")
+    val linkIdentifier: String?,
+    
+    @field:Json(name = "isSectionLinked")
+    val isSectionLinked: Boolean,
+    
+    @field:Json(name = "subjectCourse")
+    val subjectCourse: String?,
+    
+    @field:Json(name = "faculty")
+    val faculty: List<Faculty>,
+    
+    @field:Json(name = "meetingsFaculty")
+    val meetingsFaculty: List<MeetingsFaculty>
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/Faculty.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/Faculty.kt
@@ -1,0 +1,22 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Faculty(
+    @field:Json(name = "banner_id")
+    val bannerId: String?,
+    
+    @field:Json(name = "courseReferenceNumber")
+    val courseReferenceNumber: String?,
+    
+    @field:Json(name = "displayName")
+    val displayName: String?,
+    
+    @field:Json(name = "emailAddress")
+    val emailAddress: String?,
+    
+    @field:Json(name = "primaryIndicator")
+    val primaryIndicator: String?
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/MeetingTime.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/MeetingTime.kt
@@ -1,0 +1,58 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class MeetingTime(
+    @field:Json(name = "beginTime")
+    val beginTime: String?,
+    
+    @field:Json(name = "buildingDescription")
+    val buildingDescription: String?,
+    
+    @field:Json(name = "campusDescription")
+    val campusDescription: String?,
+    
+    @field:Json(name = "category")
+    val category: String?,
+    
+    @field:Json(name = "endDate")
+    val endDate: String?,
+    
+    @field:Json(name = "endTime")
+    val endTime: String?,
+    
+    @field:Json(name = "friday")
+    val friday: Boolean,
+    
+    @field:Json(name = "hoursWeek")
+    val hoursWeek: Int,
+    
+    @field:Json(name = "meetingTypeDescription")
+    val meetingTypeDescription: String?,
+    
+    @field:Json(name = "monday")
+    val monday: Boolean,
+    
+    @field:Json(name = "room")
+    val room: String?,
+    
+    @field:Json(name = "saturday")
+    val saturday: Boolean,
+    
+    @field:Json(name = "startDate")
+    val startDate: String?,
+    
+    @field:Json(name = "sunday")
+    val sunday: Boolean,
+    
+    @field:Json(name = "thursday")
+    val thursday: Boolean,
+    
+    @field:Json(name = "tuesday")
+    val tuesday: Boolean,
+    
+    @field:Json(name = "wednesday")
+    val wednesday: Boolean
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/MeetingsFaculty.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/MeetingsFaculty.kt
@@ -1,0 +1,13 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class MeetingsFaculty(
+    @field:Json(name = "category")
+    val category: String?,
+    
+    @field:Json(name = "meetingTime")
+    val meetingTime: MeetingTime?
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/RetrieveCourseInfoRequest.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/RetrieveCourseInfoRequest.kt
@@ -1,0 +1,19 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RetrieveCourseInfoRequest(
+    @field:Json(name = "txt_level")
+    val txtLevel: String,
+    
+    @field:Json(name = "txt_subject")
+    val txtSubject: String,
+    
+    @field:Json(name = "txt_courseNumber")
+    val txtCourseNumber: String,
+    
+    @field:Json(name = "txt_term")
+    val txtTerm: String
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/RetrieveCourseInfoResponse.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/model/RetrieveCourseInfoResponse.kt
@@ -1,0 +1,22 @@
+package edu.gsu.pantherwatch.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RetrieveCourseInfoResponse(
+    @field:Json(name = "success")
+    val success: Boolean,
+    
+    @field:Json(name = "totalCount")
+    val totalCount: Int,
+    
+    @field:Json(name = "data")
+    val data: List<CourseData>,
+    
+    @field:Json(name = "pageOffset")
+    val pageOffset: Int,
+    
+    @field:Json(name = "pageMaxSize")
+    val pageMaxSize: Int
+)

--- a/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/remote/PantherWatchService.kt
+++ b/frontend-android/app/src/main/java/edu/gsu/pantherwatch/data/remote/PantherWatchService.kt
@@ -1,0 +1,12 @@
+package edu.gsu.pantherwatch.data.remote
+
+import edu.gsu.pantherwatch.data.model.RetrieveCourseInfoResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.QueryMap
+
+interface PantherWatchService {
+    @GET("api/courses/search")
+    suspend fun searchCourses(
+        @QueryMap query: Map<String, String>): Response<RetrieveCourseInfoResponse>
+}

--- a/frontend-android/app/src/main/res/values/strings.xml
+++ b/frontend-android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Panther Watch</string>
+    <string name="app_name">PantherWatch</string>
 </resources>

--- a/frontend-android/gradle/libs.versions.toml
+++ b/frontend-android/gradle/libs.versions.toml
@@ -1,13 +1,17 @@
 [versions]
 agp = "8.11.1"
 kotlin = "2.0.21"
+ksp = "2.0.21-1.0.25"
 coreKtx = "1.16.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+composeBom = "2025.07.00"
+moshiKotlin = "1.15.2"
+moshiKotlinCodegen = "1.15.2"
+retrofit = "3.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,9 +28,14 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshiKotlin" }
+moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
This commit introduces Retrofit and Moshi to the Android frontend for handling network requests.

The following changes were made:
- Added Retrofit and Moshi libraries to `build.gradle.kts` and `libs.versions.toml`.
- Created data classes for API request and response models:
    - `RetrieveCourseInfoRequest.kt`
    - `RetrieveCourseInfoResponse.kt`
    - `CourseData.kt`
    - `Faculty.kt`
    - `MeetingTime.kt`
    - `MeetingsFaculty.kt`
- Implemented `PantherWatchService.kt`, a Retrofit interface for defining API endpoints.
- Added `RetrieveCourseInfoMapper.kt` to convert `RetrieveCourseInfoRequest` to a query map for the API request.
- Added Android Studio device manager configuration file (`.idea/deviceManager.xml`).
- Updated `app_name` string resource from "Panther Watch" to "PantherWatch".